### PR TITLE
fix: Add jose as dependency to example

### DIFF
--- a/functions/main/index.ts
+++ b/functions/main/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.131.0/http/server.ts"
+import * as jose from "https://deno.land/x/jose@v4.14.1/index.ts"
 
 console.log('main function started');
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

The `verifyJWT` code uses `jose.jwtVerify` but does not include it as a dependency.

## What is the current behavior?

The dependency is missing. The IDE flags it as a problem and that code path
cannot execute.

## What is the new behavior?

The dependency is included.